### PR TITLE
Add support for other RE Engine games and Chain Jiggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ https://github.com/mhvuze/MonsterHunterRiseModding/wiki/Editing-Chains-with-RE-C
 [Monster Hunter Modding Discord](https://discord.gg/gJwMdhK)
  - [AsteriskAmpersand](https://github.com/AsteriskAmpersand) - Advice and inspiration from CTC Editor
 - [Statyk](https://www.youtube.com/channel/UC2nEkiSL_X7xh6QHJcS0Wjw) - Beta testing and feedback
-- [AlphaZomega](https://github.com/alphazolam) - RE Chain 010 Template, Modified this addon to work in all games
+- [AlphaZomega](https://github.com/alphazolam/RE-Chain-Editor) - RE Chain 010 Template, Modified this addon to work in all games and other bugfixes/additions

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 # RE-Chain-Editor
+## Multi-Game Version
 This addon allows for importing and exporting of RE Engine chain (physics bone) files from Blender.
 
 ![Blender Preview](https://github.com/mhvuze/MonsterHunterRiseModding/blob/main/img/guides/models/REChainEditor/RE_Chain_Editor_Preview.png)
@@ -10,6 +11,11 @@ This addon allows for importing and exporting of RE Engine chain (physics bone) 
  ### Supported Games
 
  - **Monster Hunter Rise: Sunbreak**
+ - **Resident Evil 2 Remake**
+ - **Resident Evil 3 Remake**
+ - **Resident Evil 8**
+ - **Devil May Cry 5**
+ - **Street Fighter 6 Beta**
  
 Support for more games may be added in the future.
 
@@ -46,4 +52,4 @@ https://github.com/mhvuze/MonsterHunterRiseModding/wiki/Editing-Chains-with-RE-C
 [Monster Hunter Modding Discord](https://discord.gg/gJwMdhK)
  - [AsteriskAmpersand](https://github.com/AsteriskAmpersand) - Advice and inspiration from CTC Editor
 - [Statyk](https://www.youtube.com/channel/UC2nEkiSL_X7xh6QHJcS0Wjw) - Beta testing and feedback
-- [AlphaZomega](https://github.com/alphazolam) - RE Chain 010 Template
+- [AlphaZomega](https://github.com/alphazolam) - RE Chain 010 Template, Modified this addon to work in all games

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
 	"name": "RE Chain Editor",
 	"author": "NSA Cloud",
-	"version": (1, 0),
+	"version": (1, 1),
 	"blender": (2, 93, 0),
 	"location": "File > Import-Export",
 	"description": "Import and export RE Engine chain files.",
@@ -9,6 +9,8 @@ bl_info = {
 	"wiki_url": "https://github.com/NSACloud/RE-Chain-Editor",
 	"tracker_url": "",
 	"category": "Import-Export"}
+
+#Modified by alphaZomega to support RE2R, RE3R, RE8, RE2-3-7 RT, DMC5 and SF6 
 
 #TODO Fix Header only export
 
@@ -121,6 +123,20 @@ class ExportREChain46(bpy.types.Operator, ExportHelper):
 			self.report({"INFO"},"Exported RE Chain successfully.")
 		return {"FINISHED"}
 
+class ExportREChain52(bpy.types.Operator, ExportHelper):
+	'''Export RE Engine Chain File (Street Fighter 6 Beta)'''
+	bl_idname = "re_chain.exportfile52"
+	bl_label = "Export RE Chain (.chain.52)"
+	bl_options = {'PRESET'}
+	filename_ext = ".52"
+	filter_glob: StringProperty(default="*.chain*", options={'HIDDEN'})
+
+	def execute(self, context):
+		success = exportChainFile(self.filepath, 52)
+		if success:
+			self.report({"INFO"},"Exported RE Chain successfully.")
+		return {"FINISHED"}
+
 
 
 # Registration
@@ -131,6 +147,7 @@ classes = [
 	ExportREChain24,
 	ExportREChain39,
 	ExportREChain46,
+	ExportREChain52,
 	chainToolPanelPropertyGroup,
 	chainHeaderPropertyGroup,
 	chainWindSettingsPropertyGroup,
@@ -184,6 +201,7 @@ def re_chain_export(self, context):
 	self.layout.operator(ExportREChain39.bl_idname, text="RE Chain (.chain.39)")
 	self.layout.operator(ExportREChain46.bl_idname, text="RE Chain (.chain.46)")
 	self.layout.operator(ExportREChain.bl_idname, text="RE Chain (.chain.48)")
+	self.layout.operator(ExportREChain52.bl_idname, text="RE Chain (.chain.52)")
 
 def register():
 	for classEntry in classes:

--- a/__init__.py
+++ b/__init__.py
@@ -26,7 +26,7 @@ from .modules.re_chain_operators import WM_OT_ChainFromBone,WM_OT_CollisionFromB
 class ImportREChain(bpy.types.Operator, ImportHelper):
 	'''Import RE Engine Chain File'''
 	bl_idname = "re_chain.importfile"
-	bl_label = "Import RE Chain (.chain.48)"
+	bl_label = "Import RE Chain (.chain.*)"
 	bl_options = {'PRESET', "REGISTER", "UNDO"}
 	files : CollectionProperty(
 			name="File Path",
@@ -52,7 +52,7 @@ class ImportREChain(bpy.types.Operator, ImportHelper):
 					return {"CANCELLED"}
 		
 class ExportREChain(bpy.types.Operator, ExportHelper):
-	'''Export RE Engine Chain File'''
+	'''Export RE Engine Chain File (MHRise Sunbreak)'''
 	bl_idname = "re_chain.exportfile"
 	bl_label = "Export RE Chain (.chain.48)"
 	bl_options = {'PRESET'}
@@ -60,7 +60,63 @@ class ExportREChain(bpy.types.Operator, ExportHelper):
 	filter_glob: StringProperty(default="*.chain*", options={'HIDDEN'})
 
 	def execute(self, context):
-		success = exportChainFile(self.filepath)
+		success = exportChainFile(self.filepath, 48)
+		if success:
+			self.report({"INFO"},"Exported RE Chain successfully.")
+		return {"FINISHED"}
+
+class ExportREChain21(bpy.types.Operator, ExportHelper):
+	'''Export RE Engine Chain File (DMC5, RE2R)'''
+	bl_idname = "re_chain.exportfile21"
+	bl_label = "Export RE Chain (.chain.21)"
+	bl_options = {'PRESET'}
+	filename_ext = ".21"
+	filter_glob: StringProperty(default="*.chain*", options={'HIDDEN'})
+
+	def execute(self, context):
+		success = exportChainFile(self.filepath, 21)
+		if success:
+			self.report({"INFO"},"Exported RE Chain successfully.")
+		return {"FINISHED"}
+
+class ExportREChain24(bpy.types.Operator, ExportHelper):
+	'''Export RE Engine Chain File (RE3R, Resistance)'''
+	bl_idname = "re_chain.exportfile24"
+	bl_label = "Export RE Chain (.chain.24)"
+	bl_options = {'PRESET'}
+	filename_ext = ".24"
+	filter_glob: StringProperty(default="*.chain*", options={'HIDDEN'})
+
+	def execute(self, context):
+		success = exportChainFile(self.filepath, 24)
+		if success:
+			self.report({"INFO"},"Exported RE Chain successfully.")
+		return {"FINISHED"}
+
+class ExportREChain39(bpy.types.Operator, ExportHelper):
+	'''Export RE Engine Chain File (RE8)'''
+	bl_idname = "re_chain.exportfile39"
+	bl_label = "Export RE Chain (.chain.39)"
+	bl_options = {'PRESET'}
+	filename_ext = ".39"
+	filter_glob: StringProperty(default="*.chain*", options={'HIDDEN'})
+
+	def execute(self, context):
+		success = exportChainFile(self.filepath, 39)
+		if success:
+			self.report({"INFO"},"Exported RE Chain successfully.")
+		return {"FINISHED"}
+
+class ExportREChain46(bpy.types.Operator, ExportHelper):
+	'''Export RE Engine Chain File (Ray Tracing RE2,3,7)'''
+	bl_idname = "re_chain.exportfile46"
+	bl_label = "Export RE Chain (.chain.46)"
+	bl_options = {'PRESET'}
+	filename_ext = ".46"
+	filter_glob: StringProperty(default="*.chain*", options={'HIDDEN'})
+
+	def execute(self, context):
+		success = exportChainFile(self.filepath, 46)
 		if success:
 			self.report({"INFO"},"Exported RE Chain successfully.")
 		return {"FINISHED"}
@@ -71,6 +127,10 @@ class ExportREChain(bpy.types.Operator, ExportHelper):
 classes = [
 	ImportREChain,
 	ExportREChain,
+	ExportREChain21,
+	ExportREChain24,
+	ExportREChain39,
+	ExportREChain46,
 	chainToolPanelPropertyGroup,
 	chainHeaderPropertyGroup,
 	chainWindSettingsPropertyGroup,
@@ -116,9 +176,13 @@ classes = [
 
 
 def re_chain_import(self, context):
-	self.layout.operator(ImportREChain.bl_idname, text="RE Chain (.chain.48)")
+	self.layout.operator(ImportREChain.bl_idname, text="RE Chain (.chain.*)")
 	
 def re_chain_export(self, context):
+	self.layout.operator(ExportREChain21.bl_idname, text="RE Chain (.chain.21)")
+	self.layout.operator(ExportREChain24.bl_idname, text="RE Chain (.chain.24)")
+	self.layout.operator(ExportREChain39.bl_idname, text="RE Chain (.chain.39)")
+	self.layout.operator(ExportREChain46.bl_idname, text="RE Chain (.chain.46)")
 	self.layout.operator(ExportREChain.bl_idname, text="RE Chain (.chain.48)")
 
 def register():

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 bl_info = {
 	"name": "RE Chain Editor",
-	"author": "NSA Cloud",
+	"author": "NSA Cloud, alphaZomega",
 	"version": (1, 1),
 	"blender": (2, 93, 0),
 	"location": "File > Import-Export",
@@ -22,9 +22,9 @@ from bpy.props import StringProperty, BoolProperty, EnumProperty, CollectionProp
 from bpy.types import Operator, OperatorFileListElement
 
 from .modules.blender_re_chain import importChainFile,exportChainFile
-from .modules.re_chain_propertyGroups import chainToolPanelPropertyGroup,chainHeaderPropertyGroup,chainWindSettingsPropertyGroup,chainSettingsPropertyGroup,chainGroupPropertyGroup,chainNodePropertyGroup,chainCollisionPropertyGroup,chainClipboardPropertyGroup,chainLinkPropertyGroup
-from .modules.ui_re_chain_panels import OBJECT_PT_ChainObjectModePanel,OBJECT_PT_ChainPoseModePanel,OBJECT_PT_ChainPresetPanel,OBJECT_PT_ChainHeaderPanel,OBJECT_PT_WindSettingsPanel,OBJECT_PT_ChainSettingsPanel,OBJECT_PT_ChainGroupPanel,OBJECT_PT_ChainNodePanel,OBJECT_PT_ChainCollisionPanel,OBJECT_PT_ChainClipboardPanel,OBJECT_PT_ChainLinkPanel,OBJECT_PT_ChainVisibilityPanel
-from .modules.re_chain_operators import WM_OT_ChainFromBone,WM_OT_CollisionFromBones,WM_OT_AlignChainsToBones,WM_OT_AlignFrames,WM_OT_PointFrame,WM_OT_CopyChainProperties,WM_OT_PasteChainProperties,WM_OT_NewChainHeader,WM_OT_ApplyChainSettingsPreset,WM_OT_NewChainSettings,WM_OT_NewWindSettings,WM_OT_ApplyChainGroupPreset,WM_OT_ApplyChainNodePreset,WM_OT_ApplyWindSettingsPreset,WM_OT_SavePreset,WM_OT_OpenPresetFolder,WM_OT_NewChainLink,WM_OT_CreateChainBoneGroup,WM_OT_SwitchToPoseMode,WM_OT_SwitchToObjectMode
+from .modules.re_chain_propertyGroups import chainToolPanelPropertyGroup,chainHeaderPropertyGroup,chainWindSettingsPropertyGroup,chainSettingsPropertyGroup,chainGroupPropertyGroup,chainNodePropertyGroup,chainJigglePropertyGroup,chainCollisionPropertyGroup,chainClipboardPropertyGroup,chainLinkPropertyGroup
+from .modules.ui_re_chain_panels import OBJECT_PT_ChainObjectModePanel,OBJECT_PT_ChainPoseModePanel,OBJECT_PT_ChainPresetPanel,OBJECT_PT_ChainHeaderPanel,OBJECT_PT_WindSettingsPanel,OBJECT_PT_ChainSettingsPanel,OBJECT_PT_ChainGroupPanel,OBJECT_PT_ChainNodePanel,OBJECT_PT_ChainJigglePanel,OBJECT_PT_ChainCollisionPanel,OBJECT_PT_ChainClipboardPanel,OBJECT_PT_ChainLinkPanel,OBJECT_PT_ChainVisibilityPanel
+from .modules.re_chain_operators import WM_OT_ChainFromBone,WM_OT_CollisionFromBones,WM_OT_AlignChainsToBones,WM_OT_AlignFrames,WM_OT_PointFrame,WM_OT_CopyChainProperties,WM_OT_PasteChainProperties,WM_OT_NewChainHeader,WM_OT_ApplyChainSettingsPreset,WM_OT_NewChainSettings,WM_OT_NewWindSettings,WM_OT_NewChainJiggle,WM_OT_ApplyChainGroupPreset,WM_OT_ApplyChainNodePreset,WM_OT_ApplyWindSettingsPreset,WM_OT_SavePreset,WM_OT_OpenPresetFolder,WM_OT_NewChainLink,WM_OT_CreateChainBoneGroup,WM_OT_SwitchToPoseMode,WM_OT_SwitchToObjectMode
 class ImportREChain(bpy.types.Operator, ImportHelper):
 	'''Import RE Engine Chain File'''
 	bl_idname = "re_chain.importfile"
@@ -154,6 +154,7 @@ classes = [
 	chainSettingsPropertyGroup,
 	chainGroupPropertyGroup,
 	chainNodePropertyGroup,
+	chainJigglePropertyGroup,
 	chainCollisionPropertyGroup,
 	chainLinkPropertyGroup,
 	chainClipboardPropertyGroup,
@@ -166,6 +167,7 @@ classes = [
 	OBJECT_PT_ChainSettingsPanel,
 	OBJECT_PT_ChainGroupPanel,
 	OBJECT_PT_ChainNodePanel,
+	OBJECT_PT_ChainJigglePanel,
 	OBJECT_PT_ChainCollisionPanel,
 	OBJECT_PT_ChainLinkPanel,
 	OBJECT_PT_ChainVisibilityPanel,
@@ -177,6 +179,7 @@ classes = [
 	WM_OT_NewChainHeader,
 	WM_OT_NewChainSettings,
 	WM_OT_NewWindSettings,
+	WM_OT_NewChainJiggle,
 	WM_OT_NewChainLink,
 	WM_OT_CopyChainProperties,
 	WM_OT_PasteChainProperties,
@@ -218,6 +221,7 @@ def register():
 	bpy.types.Object.re_chain_chainsettings = bpy.props.PointerProperty(type=chainSettingsPropertyGroup)
 	bpy.types.Object.re_chain_chaingroup = bpy.props.PointerProperty(type=chainGroupPropertyGroup)
 	bpy.types.Object.re_chain_chainnode = bpy.props.PointerProperty(type=chainNodePropertyGroup)
+	bpy.types.Object.re_chain_chainjiggle = bpy.props.PointerProperty(type=chainJigglePropertyGroup)
 	bpy.types.Object.re_chain_chaincollision = bpy.props.PointerProperty(type=chainCollisionPropertyGroup)
 	bpy.types.Object.re_chain_chainlink = bpy.props.PointerProperty(type=chainLinkPropertyGroup)
 	

--- a/modules/re_chain_operators.py
+++ b/modules/re_chain_operators.py
@@ -384,9 +384,9 @@ class WM_OT_PasteChainProperties(Operator):
 						activeObj.re_chain_chaincollision[key] = value
 						
 						#I know this looks pointless but the purpose of this is force the update function to trigger, otherwise the position doesn't update
-						activeObj.re_chain_chaincollision.collisionOffset = activeObj.re_chain_chaincollision.collisionOffset
-						activeObj.re_chain_chaincollision.endCollisionOffset = activeObj.re_chain_chaincollision.endCollisionOffset
-						activeObj.re_chain_chaincollision.radius = activeObj.re_chain_chaincollision.radius
+						#activeObj.re_chain_chaincollision.collisionOffset = activeObj.re_chain_chaincollision.collisionOffset
+						#activeObj.re_chain_chaincollision.endCollisionOffset = activeObj.re_chain_chaincollision.endCollisionOffset
+						#activeObj.re_chain_chaincollision.radius = activeObj.re_chain_chaincollision.radius
 				tag_redraw(bpy.context)#Redraw property panel
 				self.report({"INFO"},"Pasted properties of " + str(clipboard.re_chain_type_name)+" object from clipboard.")
 			else:

--- a/modules/re_chain_propertyGroups.py
+++ b/modules/re_chain_propertyGroups.py
@@ -93,8 +93,10 @@ def getAttrFlagsItems(ChainSettingsData,targetObject):
 	return attrFlagsItems
 
 def addAttrFlag(attrFlag):
-	if str(attrFlag) not in attrFlagsItems:
-		attrFlagsItems.append((str(attrFlag), "AttrFlags_UNKNOWNFLAG_" + str(attrFlag), ""))
+	newAttr = (str(attrFlag), "AttrFlags_UNKNOWNFLAG_" + str(attrFlag), "")
+	if newAttr not in attrFlagsItems:
+		attrFlagsItems.append(newAttr)
+	sorted(attrFlagsItems, key=lambda attr: int(attr[0]))
 	return str(attrFlag)
 
 def update_angleLimitSize(self, context):
@@ -125,10 +127,12 @@ def update_CollisionRadius(self, context):
 						child.empty_display_size = obj.re_chain_chaincollision.radius * 100
 					else:
 						child.empty_display_size = 1
+						
 def update_NodeNameVis(self, context):
 	for obj in bpy.data.objects:
 		if obj.get("TYPE",None) == "RE_CHAIN_NODE":
 			obj.show_name = self.showNodeNames
+
 def update_CollisionNameVis(self, context):
 	collisionTypes = [
 		"RE_CHAIN_COLLISION_SINGLE",
@@ -142,6 +146,7 @@ def update_DrawNodesThroughObjects(self, context):
 	for obj in bpy.data.objects:
 		if obj.get("TYPE",None) == "RE_CHAIN_NODE" or obj.get("TYPE",None) == "RE_CHAIN_NODE_FRAME":
 			obj.show_in_front = self.drawNodesThroughObjects
+
 def update_DrawCollisionsThroughObjects(self, context):
 	collisionTypes = [
 		"RE_CHAIN_COLLISION_SINGLE",
@@ -162,7 +167,6 @@ def update_CollisionOffset(self, context):
 
 def update_EndCollisionOffset(self, context):
 	obj = self.id_data
-	#if obj.get("TYPE",None) == "RE_CHAIN_COLLISION_CAPSULE_ROOT":
 	if obj.get("TYPE",None) != "RE_CHAIN_COLLISION_CAPSULE_ROOT":
 		obj.location = obj.re_chain_chaincollision.endCollisionOffset * 100
 	else:
@@ -1443,11 +1447,6 @@ class chainNodePropertyGroup(bpy.types.PropertyGroup):
 		description="Rotation Type",#TODO Add description
 		default = 0,
 		)
-	jiggleData: IntProperty(
-		name = "Jiggle Data",
-		description = "Jiggle Data",#TODO Add description
-		default = 0,
-		)
 	unknChainNodeValue0: FloatProperty(
 		name = "Unknown 0",
 		description="Unknown 0",#TODO Add description
@@ -1456,16 +1455,6 @@ class chainNodePropertyGroup(bpy.types.PropertyGroup):
 	unknChainNodeValue1: FloatProperty(
 		name = "Unknown 1",
 		description="Unknown 1",#TODO Add description
-		default = 0.0,
-		)
-	unknChainNodeValue2: FloatProperty(
-		name = "Unknown 2",
-		description="Unknown 2",#TODO Add description
-		default = 1.0,
-		)
-	unknChainNodeValue3: FloatProperty(
-		name = "Unknown 3",
-		description="Unknown 3",#TODO Add description
 		default = 0.0,
 		)
 def getChainNode(ChainNodeData,targetObject):
@@ -1484,11 +1473,8 @@ def getChainNode(ChainNodeData,targetObject):
 	targetObject.re_chain_chainnode.collisionShape = str(ChainNodeData.collisionShape)
 	targetObject.re_chain_chainnode.attachType = ChainNodeData.attachType
 	targetObject.re_chain_chainnode.rotationType = ChainNodeData.rotationType
-	#targetObject.re_chain_chainnode.jiggleData = ChainNodeData.jiggleData
 	targetObject.re_chain_chainnode.unknChainNodeValue0 = ChainNodeData.unknChainNodeValue0
 	targetObject.re_chain_chainnode.unknChainNodeValue1 = ChainNodeData.unknChainNodeValue1
-	targetObject.re_chain_chainnode.unknChainNodeValue2 = ChainNodeData.unknChainNodeValue2
-	targetObject.re_chain_chainnode.unknChainNodeValue3 = ChainNodeData.unknChainNodeValue3
 	
 def setChainNodeData(ChainNodeData,targetObject):
 	ChainNodeData.angleLimitRad = targetObject.re_chain_chainnode.angleLimitRad 
@@ -1507,9 +1493,6 @@ def setChainNodeData(ChainNodeData,targetObject):
 	ChainNodeData.rotationType = targetObject.re_chain_chainnode.rotationType
 	ChainNodeData.unknChainNodeValue0 = targetObject.re_chain_chainnode.unknChainNodeValue0
 	ChainNodeData.unknChainNodeValue1 = targetObject.re_chain_chainnode.unknChainNodeValue1
-	ChainNodeData.unknChainNodeValue2 = targetObject.re_chain_chainnode.unknChainNodeValue2
-	ChainNodeData.unknChainNodeValue3 = targetObject.re_chain_chainnode.unknChainNodeValue3
-	#ChainNodeData.jiggleData = targetObject.re_chain_chainnode.jiggleData 
 
 	for child in targetObject.children:
 		if child.get("TYPE",None) == "RE_CHAIN_NODE_FRAME":
@@ -1519,7 +1502,93 @@ def setChainNodeData(ChainNodeData,targetObject):
 	ChainNodeData.angleLimitDirectionY = frame.rotation_quaternion[2]
 	ChainNodeData.angleLimitDirectionZ = frame.rotation_quaternion[3]
 	ChainNodeData.angleLimitDirectionW = frame.rotation_quaternion[0]
-	
+
+class chainJigglePropertyGroup(bpy.types.PropertyGroup):
+	'''range: FloatVectorProperty(
+		name = "Jiggle Range",
+		description="Jiggle Range",#TODO Add description
+		#default = (0.0,0.0,0.0),
+		step = .1,
+		subtype = "XYZ",
+		)
+	rangeOffset: FloatVectorProperty(
+		name = "Jiggle Range Offset",
+		description="Jiggle Range Offset",#TODO Add description
+		#default = (0.0,0.0,0.0),
+		step = .1,
+		subtype = "XYZ"
+		)
+	rangeAxis: FloatVectorProperty(
+		name = "Jiggle Range Axis",
+		description="Jiggle Range Axis",#TODO Add description
+		#default = (0.0,0.0,0.0,1.0),
+		step = .1,
+		subtype = "QUATERNION"
+		)'''
+	rangeShape: EnumProperty(
+		name="Collision Shape",
+		description="Apply Data to attribute.",
+		items=[ ("0", "ChainJiggleRangeShape_None", ""),
+				("1", "ChainJiggleRangeShape_OBB", ""),
+				("2", "ChainJiggleRangeShape_Sphere", ""),
+				("3", "ChainJiggleRangeShape_Cone", ""),
+			   ]
+		)
+	springForce: FloatProperty(
+		name = "Spring Force",
+		description = "Jiggle Spring Force",#TODO Add description
+		default = 0.00,
+		soft_min=0.000,
+		soft_max=1.000
+		)
+	gravityCoef: FloatProperty(
+		name = "Gravity Coefficient",
+		description = "Jiggle Gravity Coefficient",#TODO Add description
+		default = 0.00,
+		soft_min=0.000,
+		soft_max=1.000
+		)
+	damping: FloatProperty(
+		name = "Damping",
+		description = "Jiggle Damping",#TODO Add description
+		default = 0.00,
+		soft_min=0.000,
+		soft_max=1.000
+		)
+	attrFlags: EnumProperty(
+		name="Attribute Flags",
+		description="Apply Data to attribute.",
+		items=getAttrFlagsItems
+		)
+
+def getChainJiggle(ChainJiggleData,targetObject):
+	#Done manually to be able to account for chain version differences eventually
+	targetObject.re_chain_chainjiggle.rangeShape = str(ChainJiggleData.rangeShape)
+	targetObject.re_chain_chainjiggle.springForce = ChainJiggleData.springForce
+	targetObject.re_chain_chainjiggle.gravityCoef = ChainJiggleData.gravityCoef
+	targetObject.re_chain_chainjiggle.damping = ChainJiggleData.damping
+	targetObject.re_chain_chainjiggle.attrFlags = addAttrFlag(ChainJiggleData.attrFlags)
+
+def setChainJiggleData(ChainJiggleData,targetObject):
+	ChainJiggleData.rangeX = targetObject.scale[0]
+	ChainJiggleData.rangeY = targetObject.scale[1]
+	ChainJiggleData.rangeZ = targetObject.scale[2]
+
+	ChainJiggleData.rangeOffsetX = targetObject.location[0]
+	ChainJiggleData.rangeOffsetY = targetObject.location[1]
+	ChainJiggleData.rangeOffsetZ = targetObject.location[2]
+
+	ChainJiggleData.rangeAxisX = targetObject.rotation_quaternion[0]
+	ChainJiggleData.rangeAxisY = targetObject.rotation_quaternion[1]
+	ChainJiggleData.rangeAxisZ = targetObject.rotation_quaternion[2]
+	ChainJiggleData.rangeAxisW = targetObject.rotation_quaternion[3]
+
+	ChainJiggleData.rangeShape = int(targetObject.re_chain_chainjiggle.rangeShape)
+	ChainJiggleData.springForce = targetObject.re_chain_chainjiggle.springForce
+	ChainJiggleData.gravityCoef = targetObject.re_chain_chainjiggle.gravityCoef
+	ChainJiggleData.damping = targetObject.re_chain_chainjiggle.damping
+	ChainJiggleData.attrFlags = int(targetObject.re_chain_chainjiggle.attrFlags)
+
 class chainCollisionPropertyGroup(bpy.types.PropertyGroup):
 	rotationOrder: EnumProperty(
 		name="Rotation Order",
@@ -1578,7 +1647,6 @@ class chainCollisionPropertyGroup(bpy.types.PropertyGroup):
 				("6", "ChainCollisionShape_LerpSphere", ""),
 			   ]
 		)
-		
 	subDataCount: IntProperty(
 		name = "SubData Count",
 		description = "SubData Count",#TODO Add description
@@ -1748,5 +1816,6 @@ class chainClipboardPropertyGroup(bpy.types.PropertyGroup):
 	re_chain_chainsettings : PointerProperty(type=chainSettingsPropertyGroup)
 	re_chain_chaingroup : PointerProperty(type=chainGroupPropertyGroup)
 	re_chain_chainnode : PointerProperty(type=chainNodePropertyGroup)
+	re_chain_chainjiggle : PointerProperty(type=chainJigglePropertyGroup)
 	re_chain_chaincollision : PointerProperty(type=chainCollisionPropertyGroup)
 	re_chain_chainlink : PointerProperty(type=chainLinkPropertyGroup)

--- a/modules/re_chain_propertyGroups.py
+++ b/modules/re_chain_propertyGroups.py
@@ -14,6 +14,89 @@ from .pymmh3 import hash_wide
 
 from .re_chain_presets import reloadPresets
 
+attrFlagsItems = [ ("0", "AttrFlags_None", ""),
+	("1", "AttrFlags_RootRotation", ""),
+	("2", "AttrFlags_AngleLimit", ""),
+	("4", "AttrFlags_ExtraNode", ""),
+	("8", "AttrFlags_CollisionDefault", ""),
+	("16", "AttrFlags_CollisionSelf", ""),
+	("32", "AttrFlags_CollisionModel", ""),
+	("64", "AttrFlags_CollisionVGround", ""),
+	("128", "AttrFlags_CollisionCollider", ""),
+	("256", "AttrFlags_CollisionGroup", ""),
+	("512", "AttrFlags_EnablePartBlend", ""),
+	("1024", "AttrFlags_WindDefault", ""),
+	("2048", "AttrFlags_TransAnimation", ""),
+	("4096", "AttrFlags_AngleLimitRestitution", ""),
+	("8192", "AttrFlags_StretchBoth", ""),
+	("16384", "AttrFlags_EndRotConstraint", ""),
+	("3", "AttrFlags_UNKNOWNFLAG_3", ""),
+	("11", "AttrFlags_UNKNOWNFLAG_11", ""),
+	("35", "AttrFlags_UNKNOWNFLAG_35", ""),
+	("507", "AttrFlags_UNKNOWNFLAG_507", ""),
+	("1025", "AttrFlags_UNKNOWNFLAG_1025", ""),
+	("1027", "AttrFlags_UNKNOWNFLAG_1027", ""),
+	("1034", "AttrFlags_UNKNOWNFLAG_1034", ""),
+	("1035", "AttrFlags_UNKNOWNFLAG_1035", ""),
+	("1039", "AttrFlags_UNKNOWNFLAG_1039", ""),
+	("1051", "AttrFlags_UNKNOWNFLAG_1051", ""),
+	("1057", "AttrFlags_UNKNOWNFLAG_1057", ""),
+	("1059", "AttrFlags_UNKNOWNFLAG_1059", ""),
+	("1067", "AttrFlags_UNKNOWNFLAG_1067", ""),
+	("1203", "AttrFlags_UNKNOWNFLAG_1203", ""),
+	("1075", "AttrFlags_UNKNOWNFLAG_1075", ""),
+	("1083", "AttrFlags_UNKNOWNFLAG_1083", ""),
+	("1203", "AttrFlags_UNKNOWNFLAG_1203", ""),
+	("1211", "AttrFlags_UNKNOWNFLAG_1211", ""),
+	("1323", "AttrFlags_UNKNOWNFLAG_1323", ""),
+	("1331", "AttrFlags_UNKNOWNFLAG_1331", ""),
+	("1459", "AttrFlags_UNKNOWNFLAG_1459", ""),
+	("1523", "AttrFlags_UNKNOWNFLAG_1523", ""),
+	("1531", "AttrFlags_UNKNOWNFLAG_1531", ""),
+	("1547", "AttrFlags_UNKNOWNFLAG_1547", ""),
+	("32779","AttrFlags_UNKNOWNFLAG_32779",""),
+	("32803","AttrFlags_UNKNOWNFLAG_32803",""),
+	("32811","AttrFlags_UNKNOWNFLAG_32811",""),
+	("32819","AttrFlags_UNKNOWNFLAG_32819",""),
+	("32947","AttrFlags_UNKNOWNFLAG_32947",""),
+	("33275","AttrFlags_UNKNOWNFLAG_33275",""),
+	("33793","AttrFlags_UNKNOWNFLAG_33793",""),
+	("33795","AttrFlags_UNKNOWNFLAG_33795",""),
+	("33802","AttrFlags_UNKNOWNFLAG_33802",""),
+	("33803","AttrFlags_UNKNOWNFLAG_33803",""),
+	("33807","AttrFlags_UNKNOWNFLAG_33807",""),
+	("33811","AttrFlags_UNKNOWNFLAG_33811",""),
+	("33819","AttrFlags_UNKNOWNFLAG_33819",""),
+	("33825","AttrFlags_UNKNOWNFLAG_33825",""),
+	("33827","AttrFlags_UNKNOWNFLAG_33827",""),
+	("33835","AttrFlags_UNKNOWNFLAG_33835",""),
+	("33843","AttrFlags_UNKNOWNFLAG_33843",""),
+	("33851","AttrFlags_UNKNOWNFLAG_33851",""),
+	("33939","AttrFlags_UNKNOWNFLAG_33939",""),
+	("33955","AttrFlags_UNKNOWNFLAG_33955",""),
+	("33963","AttrFlags_UNKNOWNFLAG_33963",""),
+	("33971","AttrFlags_COLLLISION_ENABLED_FLAG_33971",""),
+	("33979","AttrFlags_UNKNOWNFLAG_33979",""),
+	("34043","AttrFlags_UNKNOWNFLAG_34043",""),
+	("34083","AttrFlags_UNKNOWNFLAG_34083",""),
+	("34091","AttrFlags_UNKNOWNFLAG_34091",""),
+	("34099","AttrFlags_UNKNOWNFLAG_34099",""),
+	("34211","AttrFlags_UNKNOWNFLAG_34211",""),
+	("34227","AttrFlags_UNKNOWNFLAG_34227",""),
+	("34291","AttrFlags_UNKNOWNFLAG_34291",""),
+	("34299","AttrFlags_UNKNOWNFLAG_34299",""),
+	("34315","AttrFlags_UNKNOWNFLAG_34315",""),
+	("37923","AttrFlags_UNKNOWNFLAG_37923","")
+	]
+
+def getAttrFlagsItems(ChainSettingsData,targetObject):
+	return attrFlagsItems
+
+def addAttrFlag(attrFlag):
+	if str(attrFlag) not in attrFlagsItems:
+		attrFlagsItems.append((str(attrFlag), "AttrFlags_UNKNOWNFLAG_" + str(attrFlag), ""))
+	return str(attrFlag)
+
 def update_angleLimitSize(self, context):
 	for obj in bpy.data.objects:
 		if obj.get("TYPE",None) == "RE_CHAIN_NODE_FRAME":
@@ -79,7 +162,10 @@ def update_CollisionOffset(self, context):
 
 def update_EndCollisionOffset(self, context):
 	obj = self.id_data
-	if obj.get("TYPE",None) == "RE_CHAIN_COLLISION_CAPSULE_ROOT":
+	#if obj.get("TYPE",None) == "RE_CHAIN_COLLISION_CAPSULE_ROOT":
+	if obj.get("TYPE",None) != "RE_CHAIN_COLLISION_CAPSULE_ROOT":
+		obj.location = obj.re_chain_chaincollision.endCollisionOffset * 100
+	else:
 		for child in obj.children:
 			if child.get("TYPE",None) == "RE_CHAIN_COLLISION_CAPSULE_END":
 				child.location = obj.re_chain_chaincollision.endCollisionOffset * 100
@@ -183,6 +269,7 @@ class chainHeaderPropertyGroup(bpy.types.PropertyGroup):
 				("39", ".39 (RE8)", ""),
 				("46", ".46 (Ray Tracing RE2,3,7)", ""),
 				("48", ".48 (MHRise Sunbreak)", ""),
+				("52", ".52 (Street Fighter 6 Beta)", ""),
 			   ]
 		)
 	errFlags: EnumProperty(
@@ -368,7 +455,7 @@ def getChainHeader(ChainHeaderData,targetObject):
 	targetObject.re_chain_header.rotationOrder = str(ChainHeaderData.rotationOrder)
 	targetObject.re_chain_header.defaultSettingIdx = ChainHeaderData.defaultSettingIdx
 	targetObject.re_chain_header.calculateMode = str(ChainHeaderData.calculateMode)
-	targetObject.re_chain_header.chainAttrFlags = str(ChainHeaderData.chainAttrFlags)
+	targetObject.re_chain_header.chainAttrFlags = addAttrFlag(ChainHeaderData.chainAttrFlags)
 	targetObject.re_chain_header.parameterFlag = str(ChainHeaderData.parameterFlag)
 	targetObject.re_chain_header.calculateStepTime = ChainHeaderData.calculateStepTime
 	targetObject.re_chain_header.modelCollisionSearch = ChainHeaderData.modelCollisionSearch
@@ -939,29 +1026,7 @@ class chainSettingsPropertyGroup(bpy.types.PropertyGroup):
 	groupDefaultAttr: EnumProperty(
 		name="Group Default Attribute",
 		description="Apply Data to attribute.",
-		items=[ ("0", "AttrFlags_None", ""),
-				("1", "AttrFlags_RootRotation", ""),
-				("2", "AttrFlags_AngleLimit", ""),
-				("4", "AttrFlags_ExtraNode", ""),
-				("8", "AttrFlags_CollisionDefault", ""),
-				("16", "AttrFlags_CollisionSelf", ""),
-				("32", "AttrFlags_CollisionModel", ""),
-				("64", "AttrFlags_CollisionVGround", ""),
-				("128", "AttrFlags_CollisionCollider", ""),
-				("256", "AttrFlags_CollisionGroup", ""),
-				("512", "AttrFlags_EnablePartBlend", ""),
-				("1024", "AttrFlags_WindDefault", ""),
-				("2048", "AttrFlags_TransAnimation", ""),
-				("4096", "AttrFlags_AngleLimitRestitution", ""),
-				("8192", "AttrFlags_StretchBoth", ""),
-				("16384", "AttrFlags_EndRotConstraint", ""),
-				("48", "AttrFlags_UNKNOWNFLAG_48", ""),
-				("96", "AttrFlags_UNKNOWNFLAG_96", ""),
-				("160", "AttrFlags_UNKNOWNFLAG_160", ""),
-				("176", "AttrFlags_UNKNOWNFLAG_176", ""),
-				("432", "AttrFlags_UNKNOWNFLAG_432", ""),
-				("496", "AttrFlags_UNKNOWNFLAG_496", ""),
-			   ]
+		items=getAttrFlagsItems
 		)
 	windEffectCoef: FloatProperty(
 		name = "Wind Effect Coefficient",
@@ -991,6 +1056,16 @@ class chainSettingsPropertyGroup(bpy.types.PropertyGroup):
 	unknChainSettingValue1: FloatProperty(
 		name = "Unknown 1",
 		description = "Unknown 1",#TODO Add description
+		default = 0.10,
+		)
+	unknChainSettingValue2: FloatProperty(
+		name = "Unknown 2",
+		description = "Unknown 2",#TODO Add description
+		default = 0.00,
+		)
+	unknChainSettingValue3: FloatProperty(
+		name = "Unknown 3",
+		description = "Unknown 3",#TODO Add description
 		default = 0.10,
 		)
 def getChainSettings(ChainSettingsData,targetObject):
@@ -1037,6 +1112,8 @@ def getChainSettings(ChainSettingsData,targetObject):
 	targetObject.re_chain_chainsettings.hardness = ChainSettingsData.hardness
 	targetObject.re_chain_chainsettings.unknChainSettingValue0 = ChainSettingsData.unknChainSettingValue0
 	targetObject.re_chain_chainsettings.unknChainSettingValue1 = ChainSettingsData.unknChainSettingValue1
+	targetObject.re_chain_chainsettings.unknChainSettingValue2 = ChainSettingsData.unknChainSettingValue2
+	targetObject.re_chain_chainsettings.unknChainSettingValue3 = ChainSettingsData.unknChainSettingValue3
 def setChainSettingsData(ChainSettingsData,targetObject):
 	ChainSettingsData.id = targetObject.re_chain_chainsettings.id 
 	ChainSettingsData.sprayParameterArc = targetObject.re_chain_chainsettings.sprayParameterArc 
@@ -1084,11 +1161,13 @@ def setChainSettingsData(ChainSettingsData,targetObject):
 	ChainSettingsData.hardness = targetObject.re_chain_chainsettings.hardness
 	ChainSettingsData.unknChainSettingValue0 = targetObject.re_chain_chainsettings.unknChainSettingValue0 
 	ChainSettingsData.unknChainSettingValue1 = targetObject.re_chain_chainsettings.unknChainSettingValue1 
+	ChainSettingsData.unknChainSettingValue2 = targetObject.re_chain_chainsettings.unknChainSettingValue2 
+	ChainSettingsData.unknChainSettingValue3 = targetObject.re_chain_chainsettings.unknChainSettingValue3 
 	if targetObject.parent.get("TYPE",None) == "RE_CHAIN_WINDSETTINGS":
 		ChainSettingsData.windID = targetObject.parent.re_chain_windsettings.id
 	else:
 		ChainSettingsData.windID = -1
-
+	
 class chainGroupPropertyGroup(bpy.types.PropertyGroup):
 
 	rotationOrder: EnumProperty(
@@ -1110,80 +1189,7 @@ class chainGroupPropertyGroup(bpy.types.PropertyGroup):
 	attrFlags: EnumProperty(
 		name="Attribute Flags",
 		description="Apply Data to attribute.",
-		items=[ ("0", "AttrFlags_None", ""),
-				("1", "AttrFlags_RootRotation", ""),
-				("2", "AttrFlags_AngleLimit", ""),
-				("4", "AttrFlags_ExtraNode", ""),
-				("8", "AttrFlags_CollisionDefault", ""),
-				("16", "AttrFlags_CollisionSelf", ""),
-				("32", "AttrFlags_CollisionModel", ""),
-				("64", "AttrFlags_CollisionVGround", ""),
-				("128", "AttrFlags_CollisionCollider", ""),
-				("256", "AttrFlags_CollisionGroup", ""),
-				("512", "AttrFlags_EnablePartBlend", ""),
-				("1024", "AttrFlags_WindDefault", ""),
-				("2048", "AttrFlags_TransAnimation", ""),
-				("4096", "AttrFlags_AngleLimitRestitution", ""),
-				("8192", "AttrFlags_StretchBoth", ""),
-				("16384", "AttrFlags_EndRotConstraint", ""),
-				("3", "AttrFlags_UNKNOWNFLAG_3", ""),
-				("11", "AttrFlags_UNKNOWNFLAG_11", ""),
-				("35", "AttrFlags_UNKNOWNFLAG_35", ""),
-				("507", "AttrFlags_UNKNOWNFLAG_507", ""),
-				("1025", "AttrFlags_UNKNOWNFLAG_1025", ""),
-				("1027", "AttrFlags_UNKNOWNFLAG_1027", ""),
-				("1034", "AttrFlags_UNKNOWNFLAG_1034", ""),
-				("1035", "AttrFlags_UNKNOWNFLAG_1035", ""),
-				("1039", "AttrFlags_UNKNOWNFLAG_1039", ""),
-				("1051", "AttrFlags_UNKNOWNFLAG_1051", ""),
-				("1057", "AttrFlags_UNKNOWNFLAG_1057", ""),
-				("1059", "AttrFlags_UNKNOWNFLAG_1059", ""),
-				("1067", "AttrFlags_UNKNOWNFLAG_1067", ""),
-				("1203", "AttrFlags_UNKNOWNFLAG_1203", ""),
-				("1075", "AttrFlags_UNKNOWNFLAG_1075", ""),
-				("1083", "AttrFlags_UNKNOWNFLAG_1083", ""),
-				("1203", "AttrFlags_UNKNOWNFLAG_1203", ""),
-				("1211", "AttrFlags_UNKNOWNFLAG_1211", ""),
-				("1323", "AttrFlags_UNKNOWNFLAG_1323", ""),
-				("1331", "AttrFlags_UNKNOWNFLAG_1331", ""),
-				("1459", "AttrFlags_UNKNOWNFLAG_1459", ""),
-				("1523", "AttrFlags_UNKNOWNFLAG_1523", ""),
-				("1531", "AttrFlags_UNKNOWNFLAG_1531", ""),
-				("1547", "AttrFlags_UNKNOWNFLAG_1547", ""),
-				("32779","AttrFlags_UNKNOWNFLAG_32779",""),
-				("32803","AttrFlags_UNKNOWNFLAG_32803",""),
-				("32811","AttrFlags_UNKNOWNFLAG_32811",""),
-				("32819","AttrFlags_UNKNOWNFLAG_32819",""),
-				("32947","AttrFlags_UNKNOWNFLAG_32947",""),
-				("33275","AttrFlags_UNKNOWNFLAG_33275",""),
-				("33793","AttrFlags_UNKNOWNFLAG_33793",""),
-				("33795","AttrFlags_UNKNOWNFLAG_33795",""),
-				("33802","AttrFlags_UNKNOWNFLAG_33802",""),
-				("33803","AttrFlags_UNKNOWNFLAG_33803",""),
-				("33807","AttrFlags_UNKNOWNFLAG_33807",""),
-				("33811","AttrFlags_UNKNOWNFLAG_33811",""),
-				("33819","AttrFlags_UNKNOWNFLAG_33819",""),
-				("33825","AttrFlags_UNKNOWNFLAG_33825",""),
-				("33827","AttrFlags_UNKNOWNFLAG_33827",""),
-				("33835","AttrFlags_UNKNOWNFLAG_33835",""),
-				("33843","AttrFlags_UNKNOWNFLAG_33843",""),
-				("33851","AttrFlags_UNKNOWNFLAG_33851",""),
-				("33939","AttrFlags_UNKNOWNFLAG_33939",""),
-				("33955","AttrFlags_UNKNOWNFLAG_33955",""),
-				("33963","AttrFlags_UNKNOWNFLAG_33963",""),
-				("33971","AttrFlags_COLLLISION_ENABLED_FLAG_33971",""),
-				("33979","AttrFlags_UNKNOWNFLAG_33979",""),
-				("34043","AttrFlags_UNKNOWNFLAG_34043",""),
-				("34083","AttrFlags_UNKNOWNFLAG_34083",""),
-				("34091","AttrFlags_UNKNOWNFLAG_34091",""),
-				("34099","AttrFlags_UNKNOWNFLAG_34099",""),
-				("34211","AttrFlags_UNKNOWNFLAG_34211",""),
-				("34227","AttrFlags_UNKNOWNFLAG_34227",""),
-				("34291","AttrFlags_UNKNOWNFLAG_34291",""),
-				("34299","AttrFlags_UNKNOWNFLAG_34299",""),
-				("34315","AttrFlags_UNKNOWNFLAG_34315",""),
-				("37923","AttrFlags_UNKNOWNFLAG_37923","")
-			   ]
+		items=getAttrFlagsItems,
 		)
 	collisionFilterFlags: EnumProperty(
 		name="Collision Filter Flags",
@@ -1271,11 +1277,17 @@ class chainGroupPropertyGroup(bpy.types.PropertyGroup):
 		description="Unknown 2",#TODO Add description
 		default = 0,
 		)
+	unknGroupValue3: IntProperty(
+		name = "Unknown 3",
+		description="Unknown 3",#TODO Add description
+		default = 0,
+		)
+
 def getChainGroup(ChainGroupData,targetObject):
 	#Done manually to be able to account for chain version differences eventually
 	targetObject.re_chain_chaingroup.rotationOrder = str(ChainGroupData.rotationOrder)
 	targetObject.re_chain_chaingroup.autoBlendCheckNodeNo = ChainGroupData.autoBlendCheckNodeNo
-	targetObject.re_chain_chaingroup.attrFlags = str(ChainGroupData.attrFlags)
+	targetObject.re_chain_chaingroup.attrFlags = addAttrFlag(ChainGroupData.attrFlags)
 	targetObject.re_chain_chaingroup.collisionFilterFlags = str(ChainGroupData.collisionFilterFlags)
 	targetObject.re_chain_chaingroup.extraNodeLocalPos = (ChainGroupData.extraNodeLocalPosX,ChainGroupData.extraNodeLocalPosY,ChainGroupData.extraNodeLocalPosZ)
 	targetObject.re_chain_chaingroup.tag0 = ChainGroupData.tag0
@@ -1292,6 +1304,7 @@ def getChainGroup(ChainGroupData,targetObject):
 	targetObject.re_chain_chaingroup.unknBoneHash = ChainGroupData.unknBoneHash
 	targetObject.re_chain_chaingroup.unknGroupValue1 = ChainGroupData.unknGroupValue1
 	targetObject.re_chain_chaingroup.unknGroupValue2 = ChainGroupData.unknGroupValue2
+	targetObject.re_chain_chaingroup.unknGroupValue3 = ChainGroupData.unknGroupValue3
 def setChainGroupData(ChainGroupData,targetObject):
 	ChainGroupData.rotationOrder = int(targetObject.re_chain_chaingroup.rotationOrder)
 	ChainGroupData.autoBlendCheckNodeNo = targetObject.re_chain_chaingroup.autoBlendCheckNodeNo 
@@ -1317,7 +1330,8 @@ def setChainGroupData(ChainGroupData,targetObject):
 	ChainGroupData.unknBoneHash = targetObject.re_chain_chaingroup.unknBoneHash 
 	ChainGroupData.unknGroupValue1 = targetObject.re_chain_chaingroup.unknGroupValue1 
 	ChainGroupData.unknGroupValue2 = targetObject.re_chain_chaingroup.unknGroupValue2 
-	
+	ChainGroupData.unknGroupValue3 = targetObject.re_chain_chaingroup.unknGroupValue3 
+
 	if targetObject.parent.get("TYPE",None) == "RE_CHAIN_WINDSETTINGS":
 		ChainGroupData.windID = targetObject.parent.re_chain_windsettings.id
 		
@@ -1390,47 +1404,7 @@ class chainNodePropertyGroup(bpy.types.PropertyGroup):
 	attrFlags: EnumProperty(
 		name="Attribute Flags",
 		description="Apply Data to attribute.",
-		items=[ ("0", "AttrFlags_None", ""),
-				("1", "AttrFlags_RootRotation", ""),
-				("2", "AttrFlags_AngleLimit", ""),
-				("4", "AttrFlags_ExtraNode", ""),
-				("8", "AttrFlags_CollisionDefault", ""),
-				("16", "AttrFlags_CollisionSelf", ""),
-				("32", "AttrFlags_CollisionModel", ""),
-				("64", "AttrFlags_CollisionVGround", ""),
-				("128", "AttrFlags_CollisionCollider", ""),
-				("256", "AttrFlags_CollisionGroup", ""),
-				("512", "AttrFlags_EnablePartBlend", ""),
-				("1024", "AttrFlags_WindDefault", ""),
-				("2048", "AttrFlags_TransAnimation", ""),
-				("4096", "AttrFlags_AngleLimitRestitution", ""),
-				("8192", "AttrFlags_StretchBoth", ""),
-				("16384", "AttrFlags_EndRotConstraint", ""),
-				("11", "AttrFlags_UNKNOWNFLAG_11", ""),
-				("35", "AttrFlags_UNKNOWNFLAG_35", ""),
-				("507", "AttrFlags_UNKNOWNFLAG_507", ""),
-				("1025", "AttrFlags_UNKNOWNFLAG_1025", ""),
-				("1027", "AttrFlags_UNKNOWNFLAG_1027", ""),
-				("1034", "AttrFlags_UNKNOWNFLAG_1034", ""),
-				("1035", "AttrFlags_UNKNOWNFLAG_1035", ""),
-				("1039", "AttrFlags_UNKNOWNFLAG_1039", ""),
-				("1051", "AttrFlags_UNKNOWNFLAG_1051", ""),
-				("1057", "AttrFlags_UNKNOWNFLAG_1057", ""),
-				("1059", "AttrFlags_UNKNOWNFLAG_1059", ""),
-				("1067", "AttrFlags_UNKNOWNFLAG_1067", ""),
-				("1203", "AttrFlags_UNKNOWNFLAG_1203", ""),
-				("1075", "AttrFlags_UNKNOWNFLAG_1075", ""),
-				("1083", "AttrFlags_UNKNOWNFLAG_1083", ""),
-				("1203", "AttrFlags_UNKNOWNFLAG_1203", ""),
-				("1211", "AttrFlags_UNKNOWNFLAG_1211", ""),
-				("1323", "AttrFlags_UNKNOWNFLAG_1323", ""),
-				("1331", "AttrFlags_UNKNOWNFLAG_1331", ""),
-				("1459", "AttrFlags_UNKNOWNFLAG_1459", ""),
-				("1533", "AttrFlags_UNKNOWNFLAG_1523", ""),
-				("1531", "AttrFlags_UNKNOWNFLAG_1531", ""),
-				("1547", "AttrFlags_UNKNOWNFLAG_1547", ""),
-				
-			   ]
+		items=getAttrFlagsItems
 		)
 	windCoef: FloatProperty(
 		name = "Wind Coefficient",
@@ -1504,7 +1478,7 @@ def getChainNode(ChainNodeData,targetObject):
 	targetObject.re_chain_chainnode.collisionFilterFlags = str(ChainNodeData.collisionFilterFlags)
 	targetObject.re_chain_chainnode.capsuleStretchRate0 = ChainNodeData.capsuleStretchRate0
 	targetObject.re_chain_chainnode.capsuleStretchRate1 = ChainNodeData.capsuleStretchRate1
-	targetObject.re_chain_chainnode.attrFlags = str(ChainNodeData.attrFlags)
+	targetObject.re_chain_chainnode.attrFlags = addAttrFlag(ChainNodeData.attrFlags)
 	targetObject.re_chain_chainnode.windCoef = ChainNodeData.windCoef
 	targetObject.re_chain_chainnode.angleMode = str(ChainNodeData.angleMode)
 	targetObject.re_chain_chainnode.collisionShape = str(ChainNodeData.collisionShape)

--- a/modules/re_chain_propertyGroups.py
+++ b/modules/re_chain_propertyGroups.py
@@ -169,10 +169,21 @@ class chainToolPanelPropertyGroup(bpy.types.PropertyGroup):
 		)
 class chainHeaderPropertyGroup(bpy.types.PropertyGroup):
 
-	version: IntProperty(
+	'''version: IntProperty(
 		name = "Chain Version",
 		description="Chain Version",#TODO Add description
-		default = 35,
+		#default = 35,
+		)'''
+	version: EnumProperty(
+		name = "Chain Version",
+		description="Chain Version",#TODO Add description
+		items=[ ("21", ".21 (RE2R, DMC5)", ""),
+				("24", ".24 (RE3R, Resistance)", ""),
+				("35", ".35 (MHRise)", ""),
+				("39", ".39 (RE8)", ""),
+				("46", ".46 (Ray Tracing RE2,3,7)", ""),
+				("48", ".48 (MHRise Sunbreak)", ""),
+			   ]
 		)
 	errFlags: EnumProperty(
 		name="Error Flags",
@@ -351,7 +362,7 @@ class chainHeaderPropertyGroup(bpy.types.PropertyGroup):
   
 def getChainHeader(ChainHeaderData,targetObject):
 	#Done manually to be able to account for chain version differences eventually
-	targetObject.re_chain_header.version = ChainHeaderData.version
+	targetObject.re_chain_header.version = str(ChainHeaderData.version)
 	targetObject.re_chain_header.errFlags = str(ChainHeaderData.errFlags)
 	targetObject.re_chain_header.masterSize = ChainHeaderData.masterSize
 	targetObject.re_chain_header.rotationOrder = str(ChainHeaderData.rotationOrder)
@@ -373,7 +384,7 @@ def getChainHeader(ChainHeaderData,targetObject):
 
 
 def setChainHeaderData(ChainHeaderData,targetObject):
-	ChainHeaderData.version = targetObject.re_chain_header.version 
+	ChainHeaderData.version = int(targetObject.re_chain_header.version) 
 	ChainHeaderData.errFlags = int(targetObject.re_chain_header.errFlags)
 	ChainHeaderData.masterSize = targetObject.re_chain_header.masterSize 
 	ChainHeaderData.rotationOrder = int(targetObject.re_chain_header.rotationOrder)
@@ -749,6 +760,7 @@ class chainSettingsPropertyGroup(bpy.types.PropertyGroup):
 				("2", "SettingAttrFlags_VirtualGroundRoot", ""),
 				("3", "SettingAttrFlags_UNKNOWNFLAG_3", ""),
 				("4", "SettingAttrFlags_VirtualGroundTarget", ""),
+				("5", "SettingAttrFlags_UNKNOWNFLAG_4", ""),
 				("8", "SettingAttrFlags_IgnoreSameGroupCollision", ""),
 				("9", "SettingAttrFlags_UNKNOWNFLAG_9", ""),
 				("6", "SettingAttrFlags_VirtualGroundMask", ""),
@@ -943,6 +955,7 @@ class chainSettingsPropertyGroup(bpy.types.PropertyGroup):
 				("4096", "AttrFlags_AngleLimitRestitution", ""),
 				("8192", "AttrFlags_StretchBoth", ""),
 				("16384", "AttrFlags_EndRotConstraint", ""),
+				("48", "AttrFlags_UNKNOWNFLAG_48", ""),
 				("96", "AttrFlags_UNKNOWNFLAG_96", ""),
 				("160", "AttrFlags_UNKNOWNFLAG_160", ""),
 				("176", "AttrFlags_UNKNOWNFLAG_176", ""),
@@ -1015,7 +1028,10 @@ def getChainSettings(ChainSettingsData,targetObject):
 	targetObject.re_chain_chainsettings.stretchInteractionRatio = ChainSettingsData.stretchInteractionRatio
 	targetObject.re_chain_chainsettings.angleLimitInteractionRatio = ChainSettingsData.angleLimitInteractionRatio
 	targetObject.re_chain_chainsettings.shootingElasticLimitRate = ChainSettingsData.shootingElasticLimitRate
-	targetObject.re_chain_chainsettings.groupDefaultAttr = str(ChainSettingsData.groupDefaultAttr)
+	try:
+		targetObject.re_chain_chainsettings.groupDefaultAttr = str(ChainSettingsData.groupDefaultAttr)
+	except:
+		pass
 	targetObject.re_chain_chainsettings.windEffectCoef = ChainSettingsData.windEffectCoef
 	targetObject.re_chain_chainsettings.velocityLimit = ChainSettingsData.velocityLimit
 	targetObject.re_chain_chainsettings.hardness = ChainSettingsData.hardness
@@ -1545,7 +1561,7 @@ class chainCollisionPropertyGroup(bpy.types.PropertyGroup):
 	collisionOffset: FloatVectorProperty(
 		name = "Collision Offset",
 		description="Set the positional offset of the collision from the bone",
-		default = (0.0,0.0,0.0),
+		#default = (0.0,0.0,0.0),
 		step = .1,
 		subtype = "XYZ",
 		update = update_CollisionOffset
@@ -1553,7 +1569,7 @@ class chainCollisionPropertyGroup(bpy.types.PropertyGroup):
 	endCollisionOffset: FloatVectorProperty(
 		name = "End Collision Offset",
 		description="Set the collision offset from the end bone for collision capsules",
-		default = (0.0,0.0,0.0),
+		#default = (0.0,0.0,0.0),
 		step = .1,
 		subtype = "XYZ",
 		update = update_EndCollisionOffset

--- a/modules/ui_re_chain_panels.py
+++ b/modules/ui_re_chain_panels.py
@@ -332,8 +332,12 @@ class OBJECT_PT_ChainSettingsPanel(Panel):
 		col2.prop(re_chain_chainsettings, "windEffectCoef",slider=True)
 		col2.prop(re_chain_chainsettings, "velocityLimit")
 		col2.prop(re_chain_chainsettings, "hardness",slider=True)
-		col2.prop(re_chain_chainsettings, "unknChainSettingValue0")
-		col2.prop(re_chain_chainsettings, "unknChainSettingValue1")
+		if version >= 48:
+			col2.prop(re_chain_chainsettings, "unknChainSettingValue0")
+			col2.prop(re_chain_chainsettings, "unknChainSettingValue1")
+		if version >= 52:
+			col2.prop(re_chain_chainsettings, "unknChainSettingValue2")
+			col2.prop(re_chain_chainsettings, "unknChainSettingValue3")
 
 class OBJECT_PT_ChainGroupPanel(Panel):
 	bl_label = "RE Chain Group Settings"
@@ -367,12 +371,15 @@ class OBJECT_PT_ChainGroupPanel(Panel):
 			col2.prop(re_chain_chaingroup, "dampingNoise1")
 			col2.prop(re_chain_chaingroup, "endRotConstMax")
 			col2.prop(re_chain_chaingroup, "angleLimitDirectionMode")
+		if version >= 48:
 			col2.prop(re_chain_chaingroup, "unknGroupValue0")
 			col2.prop(re_chain_chaingroup, "unknGroupValue0B")
 			col2.prop(re_chain_chaingroup, "unknGroupValue1")
 			col2.prop(re_chain_chaingroup, "unknGroupValue2")
+		if version >= 52:
+			col2.prop(re_chain_chaingroup, "unknGroupValue3")
 		col2.prop(re_chain_chaingroup, "extraNodeLocalPos")
-		if version >= 35:
+		if version >= 48:
 			col2.prop(re_chain_chaingroup, "unknBoneHash")
 		col2.prop(re_chain_chaingroup, "autoBlendCheckNodeNo") 
 		if version >= 35:

--- a/modules/ui_re_chain_panels.py
+++ b/modules/ui_re_chain_panels.py
@@ -34,12 +34,14 @@ class OBJECT_PT_ChainObjectModePanel(Panel):
 		layout.operator("re_chain.create_chain_header")
 		layout.operator("re_chain.create_chain_settings")
 		layout.operator("re_chain.create_wind_settings")
+		layout.operator("re_chain.create_chain_jiggle")
 		layout.operator("re_chain.create_chain_link")
 		layout.operator("re_chain.align_chains_to_bone")
 		layout.label(text="Create new chains in Pose Mode.")
 		layout.operator("re_chain.switch_to_pose")
 		#layout.operator("re_chain.align_frames")#Not implemented yet
 		#layout.operator("re_chain.point_frame")#Not implemented yet
+
 class OBJECT_PT_ChainClipboardPanel(Panel):
 	bl_label = "RE Chain: Clipboard"
 	bl_idname = "OBJECT_PT_chain_clipboard_panel"
@@ -86,6 +88,7 @@ class OBJECT_PT_ChainPoseModePanel(Panel):
 		layout.operator("re_chain.create_chain_bone_group")
 		layout.label(text="Configure chains in Object Mode.")
 		layout.operator("re_chain.switch_to_object")
+
 class OBJECT_PT_ChainPresetPanel(Panel):
 	bl_label = "RE Chain: Presets"
 	bl_idname = "OBJECT_PT_chain_presets_panel"
@@ -430,8 +433,39 @@ class OBJECT_PT_ChainNodePanel(Panel):
 		if version >= 35:
 			col2.prop(re_chain_chainnode, "unknChainNodeValue0")
 			col2.prop(re_chain_chainnode, "unknChainNodeValue1")
-			col2.prop(re_chain_chainnode, "unknChainNodeValue2")
-			col2.prop(re_chain_chainnode, "unknChainNodeValue3")
+
+
+class OBJECT_PT_ChainJigglePanel(Panel):
+	bl_label = "RE Chain Jiggle Settings"
+	bl_idname = "OBJECT_PT_chain_jiggle_panel"
+	bl_space_type = "PROPERTIES"   
+	bl_region_type = "WINDOW"
+	bl_category = "RE Chain Jiggle Settings"
+	bl_context = "object"
+
+
+	@classmethod
+	def poll(self,context):
+		
+		return context and context.object.mode == "OBJECT" and context.active_object.get("TYPE",None) == "RE_CHAIN_JIGGLE"
+
+	def draw(self, context):
+		layout = self.layout
+		object = context.active_object
+		re_chain_chainjiggle = object.re_chain_chainjiggle
+		split = layout.split(factor=0.01)
+		col1 = split.column()
+		col2 = split.column()
+		col2.alignment='RIGHT'
+		col2.use_property_split = True
+		#col2.prop(re_chain_chainjiggle, "range")
+		#col2.prop(re_chain_chainjiggle, "rangeOffset") 
+		#col2.prop(re_chain_chainjiggle, "rangeAxis")
+		col2.prop(re_chain_chainjiggle, "rangeShape")
+		col2.prop(re_chain_chainjiggle, "springForce",slider = True)
+		col2.prop(re_chain_chainjiggle, "gravityCoef",slider = True)
+		col2.prop(re_chain_chainjiggle, "damping",slider = True)
+		col2.prop(re_chain_chainjiggle, "attrFlags")
 		
 class OBJECT_PT_ChainCollisionPanel(Panel):
 	bl_label = "RE Chain Collision Settings"

--- a/modules/ui_re_chain_panels.py
+++ b/modules/ui_re_chain_panels.py
@@ -6,6 +6,7 @@ from bpy.types import (Panel,
 					   PropertyGroup,
 					   )
 
+from .file_re_chain import version
 
 def tag_redraw(context, space_type="PROPERTIES", region_type="WINDOW"):
 	for window in context.window_manager.windows:
@@ -173,6 +174,7 @@ class OBJECT_PT_ChainHeaderPanel(Panel):
 		layout = self.layout
 		object = context.active_object
 		re_chain_header = object.re_chain_header
+		global version; version = int(re_chain_header.version)
 
 		split = layout.split(factor=0.01)
 		col1 = split.column()
@@ -300,18 +302,22 @@ class OBJECT_PT_ChainSettingsPanel(Panel):
 		col2.prop(re_chain_chainsettings, "gravity")
 		col2.prop(re_chain_chainsettings, "muzzleVelocity")
 		col2.prop(re_chain_chainsettings, "damping",slider=True)
-		col2.prop(re_chain_chainsettings, "minDamping",slider=True)
-		col2.prop(re_chain_chainsettings, "dampingPow")
+		if version >= 24:
+			col2.prop(re_chain_chainsettings, "minDamping",slider=True)
+			col2.prop(re_chain_chainsettings, "dampingPow")
 		col2.prop(re_chain_chainsettings, "secondDamping",slider=True)
-		col2.prop(re_chain_chainsettings, "secondMinDamping",slider=True)
-		col2.prop(re_chain_chainsettings, "secondDampingSpeed")		
-		col2.prop(re_chain_chainsettings, "secondDampingPow")
-		col2.prop(re_chain_chainsettings, "collideMaxVelocity")
+		if version >= 24:
+			col2.prop(re_chain_chainsettings, "secondMinDamping",slider=True)
+		col2.prop(re_chain_chainsettings, "secondDampingSpeed")	
+		if version >= 24:	
+			col2.prop(re_chain_chainsettings, "secondDampingPow")
+			col2.prop(re_chain_chainsettings, "collideMaxVelocity")
 		col2.prop(re_chain_chainsettings, "springForce")
-		col2.prop(re_chain_chainsettings, "springLimitRate")
-		col2.prop(re_chain_chainsettings, "springMaxVelocity")
-		col2.prop(re_chain_chainsettings, "springCalcType")
-		col2.prop(re_chain_chainsettings, "unknFlag")
+		if version >= 24:
+			col2.prop(re_chain_chainsettings, "springLimitRate")
+			col2.prop(re_chain_chainsettings, "springMaxVelocity")
+			col2.prop(re_chain_chainsettings, "springCalcType")
+			col2.prop(re_chain_chainsettings, "unknFlag")
 		col2.prop(re_chain_chainsettings, "reduceSelfDistanceRate",slider=True)
 		col2.prop(re_chain_chainsettings, "secondReduceDistanceRate",slider=True)
 		col2.prop(re_chain_chainsettings, "secondReduceDistanceSpeed")
@@ -356,23 +362,26 @@ class OBJECT_PT_ChainGroupPanel(Panel):
 		col2.prop(re_chain_chaingroup, "rotationOrder")
 		col2.prop(re_chain_chaingroup, "attrFlags")
 		col2.prop(re_chain_chaingroup, "collisionFilterFlags")
-		col2.prop(re_chain_chaingroup, "dampingNoise0")
-		col2.prop(re_chain_chaingroup, "dampingNoise1")
-		col2.prop(re_chain_chaingroup, "endRotConstMax")
-		col2.prop(re_chain_chaingroup, "angleLimitDirectionMode")
-		col2.prop(re_chain_chaingroup, "unknGroupValue0")
-		col2.prop(re_chain_chaingroup, "unknGroupValue0B")
-		col2.prop(re_chain_chaingroup, "unknGroupValue1")
-		col2.prop(re_chain_chaingroup, "unknGroupValue2")
+		if version >= 35:
+			col2.prop(re_chain_chaingroup, "dampingNoise0")
+			col2.prop(re_chain_chaingroup, "dampingNoise1")
+			col2.prop(re_chain_chaingroup, "endRotConstMax")
+			col2.prop(re_chain_chaingroup, "angleLimitDirectionMode")
+			col2.prop(re_chain_chaingroup, "unknGroupValue0")
+			col2.prop(re_chain_chaingroup, "unknGroupValue0B")
+			col2.prop(re_chain_chaingroup, "unknGroupValue1")
+			col2.prop(re_chain_chaingroup, "unknGroupValue2")
 		col2.prop(re_chain_chaingroup, "extraNodeLocalPos")
-		col2.prop(re_chain_chaingroup, "unknBoneHash")
+		if version >= 35:
+			col2.prop(re_chain_chaingroup, "unknBoneHash")
 		col2.prop(re_chain_chaingroup, "autoBlendCheckNodeNo") 
-		col2.prop(re_chain_chaingroup, "tagCount")
-		col2.prop(re_chain_chaingroup, "tag0")
-		col2.prop(re_chain_chaingroup, "tag1")
-		col2.prop(re_chain_chaingroup, "tag2")
-		col2.prop(re_chain_chaingroup, "tag3")
-		
+		if version >= 35:
+			col2.prop(re_chain_chaingroup, "tagCount")
+			col2.prop(re_chain_chaingroup, "tag0")
+			col2.prop(re_chain_chaingroup, "tag1")
+			col2.prop(re_chain_chaingroup, "tag2")
+			col2.prop(re_chain_chaingroup, "tag3")
+
 class OBJECT_PT_ChainNodePanel(Panel):
 	bl_label = "RE Chain Node Settings"
 	bl_idname = "OBJECT_PT_chain_node_panel"
@@ -411,10 +420,11 @@ class OBJECT_PT_ChainNodePanel(Panel):
 		col2.prop(re_chain_chainnode, "attachType")
 		col2.prop(re_chain_chainnode, "rotationType")
 		#col2.prop(re_chain_chainnode, "jiggleData")
-		col2.prop(re_chain_chainnode, "unknChainNodeValue0")
-		col2.prop(re_chain_chainnode, "unknChainNodeValue1")
-		col2.prop(re_chain_chainnode, "unknChainNodeValue2")
-		col2.prop(re_chain_chainnode, "unknChainNodeValue3")
+		if version >= 35:
+			col2.prop(re_chain_chainnode, "unknChainNodeValue0")
+			col2.prop(re_chain_chainnode, "unknChainNodeValue1")
+			col2.prop(re_chain_chainnode, "unknChainNodeValue2")
+			col2.prop(re_chain_chainnode, "unknChainNodeValue3")
 		
 class OBJECT_PT_ChainCollisionPanel(Panel):
 	bl_label = "RE Chain Collision Settings"
@@ -440,12 +450,14 @@ class OBJECT_PT_ChainCollisionPanel(Panel):
 		col2 = split.column()
 		col2.alignment='RIGHT'
 		col2.use_property_split = True
-		col2.prop(re_chain_chaincollision, "rotationOrder")
+		if version >= 48:
+			col2.prop(re_chain_chaincollision, "rotationOrder")
 		col2.prop(re_chain_chaincollision, "radius")
 		col2.prop(re_chain_chaincollision, "collisionOffset")
 		col2.prop(re_chain_chaincollision, "endCollisionOffset")	
 		col2.prop(re_chain_chaincollision, "lerp")
-		col2.prop(re_chain_chaincollision, "unknCollisionValue") 
+		if version >= 48:
+			col2.prop(re_chain_chaincollision, "unknCollisionValue") 
 		col2.prop(re_chain_chaincollision, "chainCollisionShape")
 		col2.prop(re_chain_chaincollision, "subDataCount")
 		col2.prop(re_chain_chaincollision, "collisionFilterFlags")


### PR DESCRIPTION
Includes updates for the Chain Editor that bring support for RE7, RE8, RE2R, RE3R, DMC5, RE RT, and SF6.
Also adds management of Chain Jiggle structs, which can be added/activated on Chain Nodes for games RE8+.
Includes some additional bugfixes and modifications, some of which aim to make the Editor more accepting of the many possible variables and conditions (such as missing bones or missing enums) when importing chain files from all these different games.